### PR TITLE
Update the 2 sui implementations to more closely match the aptos implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This benchmark measures E2E Latency across several blockchains. The numbers prod
 
 The benchmark leverages TS SDKs for the respective blockchains. The logic of 'Coin transfer' transaction for a blockchain is present in the corresponding 'index.js' file. Some common helper functions are present in 'common.js'.
 
-To collect metrics we are using a timeseries database that supports the prometheus remote_write protocol: https://prometheus.io/docs/concepts/remote_write_spec/. 
+To collect metrics we are using a timeseries database that supports the prometheus remote_write protocol: https://prometheus.io/docs/concepts/remote_write_spec/.
 
 ## Prerequisites
 * Using a wallet (or client), setup Web3 accounts on the corresponding blockchain(s).
@@ -26,6 +26,7 @@ Pass the env variables and run using node. Some examples are below:
 * Solana: `PING_INTERVAL=900 CHAIN_NAME=mainnet-beta METRICS_URL=<url> METRICS_AUTH_TOKEN=<token> METRICS_TAG=<tag> ACC1_PRIVATE_KEY=<priv_key_sender> ACC2_PRIVATE_KEY=<priv_key_receiver> COMMITMENT_LEVEL=confirmed node index.js`
 * ETH_BASED_CHAINS (Optimism): `PING_INTERVAL=900 CHAIN_NAME=mainnet METRICS_URL=<url> METRICS_AUTH_TOKEN=<token> METRICS_TAG=<tag> COIN_TRANSFER_LATENCY_METRIC_NAME=e2e_p2p_txn_latency_optimism ACC1_PRIVATE_KEY=<priv_key_sender> ACC1_ADDR=<public_addr_sender> ACC2_ADDR=<public_addr_receiver> URL=https://mainnet.optimism.io TRANSFER_AMT=<amt> node index.js`
 * NEAR: `PING_INTERVAL=900 CHAIN_NAME=mainnet METRICS_URL=<url> METRICS_AUTH_TOKEN=<token> METRICS_TAG=<tag> ACC1_PRIVATE_KEY=<priv_key_sender> ACC1_ID=<public_addr_sender> ACC2_ID=<public_addr_receiver> URL=https://rpc.mainnet.near.org node index.js`
+* SUI: `PING_INTERVAL=900 CHAIN_NAME=mainnet METRICS_URL=<url> METRICS_AUTH_TOKEN=<token> METRICS_TAG=<tag> ACC1_PRIVATE_KEY=<private-key> URL=https://fullnode.testnet.sui.io:443 node index.js`
 
 Note: Some env variables are optional, and env variables needed might change based on the script
 

--- a/aptos/p2p_transfer/index.js
+++ b/aptos/p2p_transfer/index.js
@@ -35,9 +35,9 @@ const main = async () => {
   const SENDER_PRIVATE_KEY = process.env.ACC1_PRIVATE_KEY;
   const sender = Account.fromPrivateKey({ privateKey: new Ed25519PrivateKey(SENDER_PRIVATE_KEY) });
 
-  const RECEIVER_PRIVATE_KEY = process.env.ACC1_PRIVATE_KEY;
+  const RECEIVER_PRIVATE_KEY = process.env.ACC2_PRIVATE_KEY;
   const receiver = Account.fromPrivateKey({ privateKey: new Ed25519PrivateKey(RECEIVER_PRIVATE_KEY) });
-  
+
   const transferAbi = {
     typeParameters: [{ constraints: [] }],
     parameters: [new TypeTagAddress(), new TypeTagU64()],

--- a/sui/p2p_transfer/README.md
+++ b/sui/p2p_transfer/README.md
@@ -1,0 +1,22 @@
+## Setup
+
+1. Copy the following files into the same directory:
+    * `package.json`
+    * `index.js`
+    * `common.js` from the root of the repo
+2. Install dependencies
+    * run `npm install`, or use another package manager like `pnpm` or `yarn`
+3. Get a private key with some sui for running the transfer test
+    * The key should look something like `suiprivkey123abc...`
+        * You can export a private key from the sui CLI using `sui keytool export --key-identity your-alias`
+    * For testing you can use the sui CLI to create a new keypair with testnet sui:
+        1. run `sui client new-address ed25519` to create a new keypair
+        2. run `sui client faucet` to request sui
+        3. run `sui keytool export --key-identity alias-from-ste-1`  to export the private key in the right format
+4. Run `index.ts` with environment variables to run the benchmark
+    * To run against testnet run: `ACC1_PRIVATE_KEY=<private-key> URL=https://fullnode.testnet.sui.io:443 node index.js`
+    * To run against mainnet remove the URL variable `ACC1_PRIVATE_KEY=<private-key> node index.js`
+    * To report the metrics add the appropriate metrics environment variables:
+        - `METRICS_URL=<url> METRICS_AUTH_TOKEN=<token> METRICS_TAG=<tag> ACC1_PRIVATE_KEY=<private-key> node index.js`
+
+

--- a/sui/p2p_transfer/README.md
+++ b/sui/p2p_transfer/README.md
@@ -16,6 +16,7 @@
 4. Run `index.ts` with environment variables to run the benchmark
     * To run against testnet run: `ACC1_PRIVATE_KEY=<private-key> URL=https://fullnode.testnet.sui.io:443 node index.js`
     * To run against mainnet remove the URL variable `ACC1_PRIVATE_KEY=<private-key> node index.js`
+    * For consistency with other tests, you acn set `ACC2_PRIVATE_KEY` to a second private key.  This shouldn't affect the e2e latency, but ensures the test more accurately reflects the same operation as the benchmarks for other chains.
     * To report the metrics add the appropriate metrics environment variables:
         - `METRICS_URL=<url> METRICS_AUTH_TOKEN=<token> METRICS_TAG=<tag> ACC1_PRIVATE_KEY=<private-key> node index.js`
 

--- a/sui/p2p_transfer/index.js
+++ b/sui/p2p_transfer/index.js
@@ -19,6 +19,9 @@ function getKeyPairFromExportedPrivateKey(privateKey) {
 const main = async () => {
   const SENDER_PRIVATE_KEY = process.env.ACC1_PRIVATE_KEY;
   const sender_keypair = getKeyPairFromExportedPrivateKey(SENDER_PRIVATE_KEY);
+  const RECEIVER_PRIVATE_KEY = process.env.ACC2_PRIVATE_KEY || process.env.ACC1_PRIVATE_KEY;
+  const receiver_keypair = getKeyPairFromExportedPrivateKey(RECEIVER_PRIVATE_KEY);
+  const receiver_address = receiver_keypair.getPublicKey().toSuiAddress();
 
 
   // create a new SuiClient object pointing to the network you want to use
@@ -34,7 +37,7 @@ const main = async () => {
     try {
       const txb = new TransactionBlock();
       const [coin] = txb.splitCoins(txb.gas, [txb.pure(1)]);
-      txb.transferObjects([coin], sender_keypair.toSuiAddress());
+      txb.transferObjects([coin], receiver_address.toSuiAddress());
       txb.setSender(sender_keypair.toSuiAddress());
       txb.setGasBudget(5_000_000)
       txb.setGasPrice(gasPrice);

--- a/sui/p2p_transfer/index.js
+++ b/sui/p2p_transfer/index.js
@@ -5,6 +5,8 @@ import { decodeSuiPrivateKey } from '@mysten/sui.js/cryptography';
 import { getMetricPayload, pushMetrics, sleepAsync } from './common.js';
 
 const COIN_TRANSFER_LATENCY_METRIC_NAME = "e2e_p2p_txn_latency_sui";
+const COIN_TRANSFER_BUILD_LATENCY_METRIC_NAME = "e2e_p2p_txn_latency_build_sui";
+const COIN_TRANSFER_SUBMIT_LATENCY_METRIC_NAME = "e2e_p2p_txn_latency_sign_and_submit_sui";
 const COIN_TRANSFER_SUCCESS_METRIC_NAME = COIN_TRANSFER_LATENCY_METRIC_NAME + "_success";
 const CHAIN_NAME = process.env.CHAIN_NAME;
 const PING_INTERVAL = process.env.PING_INTERVAL * 1000;
@@ -36,31 +38,33 @@ const main = async () => {
       const txb = new TransactionBlock();
       const [coin] = txb.splitCoins(txb.gas, [txb.pure(1)]);
       txb.transferObjects([coin], receiver_address);
+      txb.setSender(sender_keypair.toSuiAddress());
+      txb.setGasBudget(5_000_000)
+
+      const buildStartTime = performance.now();
+      const bytes = await txb.build({ client: suiClient });
 
       const startTime = performance.now();
-      const transfer_resp = await suiClient.signAndExecuteTransactionBlock({signer: sender_keypair, transactionBlock: txb, 	options: {
+      await suiClient.signAndExecuteTransactionBlock({signer: sender_keypair, transactionBlock: bytes, options: {
           showBalanceChanges: true,
           showEffects: true,
           showEvents: true,
           showInput: true,
           showObjectChanges: true,
           showRawInput: true,
-      },});
-      const wait_resp = await suiClient.waitForTransactionBlock({ digest: transfer_resp.digest, options: {
-          showBalanceChanges: true,
-          showEffects: true,
-          showEvents: true,
-          showInput: true,
-          showObjectChanges: true,
-          showRawInput: true,
-      }, })
-      const endTime = performance.now();
-      const latency = (endTime - startTime) / 1000;
-      console.log(`E2E latency for p2p transfer: ${latency} s`);
+      } });
 
-      const latency_metrics_payload = getMetricPayload(COIN_TRANSFER_LATENCY_METRIC_NAME, {"chain_name": CHAIN_NAME}, latency);
-      pushMetrics(latency_metrics_payload);
-      pushMetrics(getMetricPayload(COIN_TRANSFER_SUCCESS_METRIC_NAME, {"chain_name": CHAIN_NAME}, 0));
+      const endTime = performance.now();
+
+      const buildLatency = (startTime - buildStartTime) / 1000;
+      const submitLatency = (endTime - startTime) / 1000;
+      const latency = (endTime - startTime) / 1000;
+      console.log(`Build latency for p2p transfer: ${buildLatency} s; Submit Latency: ${submitLatency} s; E2E latency for p2p transfer: ${latency} s`);
+
+      pushMetrics(getMetricPayload(COIN_TRANSFER_LATENCY_METRIC_NAME, {"chain_name": CHAIN_NAME}, latency));
+      pushMetrics(getMetricPayload(COIN_TRANSFER_SUCCESS_METRIC_NAME, {"chain_name": CHAIN_NAME}, 1));
+      pushMetrics(getMetricPayload(COIN_TRANSFER_BUILD_LATENCY_METRIC_NAME, {"chain_name": CHAIN_NAME}, buildLatency));
+      pushMetrics(getMetricPayload(COIN_TRANSFER_SUBMIT_LATENCY_METRIC_NAME, {"chain_name": CHAIN_NAME}, submitLatency));
     } catch (error) {
       console.log('Error:', error.message);
       pushMetrics(getMetricPayload(COIN_TRANSFER_SUCCESS_METRIC_NAME, {"chain_name": CHAIN_NAME}, 0));

--- a/sui/p2p_transfer/index.js
+++ b/sui/p2p_transfer/index.js
@@ -31,33 +31,25 @@ const main = async () => {
   }
   const suiClient = new SuiClient({ url: url });
   const gasPrice = await suiClient.getReferenceGasPrice()
-  let gasCoin = null
 
   while (true) {
     try {
       const txb = new TransactionBlock();
       const [coin] = txb.splitCoins(txb.gas, [txb.pure(1)]);
-      txb.transferObjects([coin], receiver_address.toSuiAddress());
+      txb.transferObjects([coin], receiver_address);
       txb.setSender(sender_keypair.toSuiAddress());
       txb.setGasBudget(5_000_000)
       txb.setGasPrice(gasPrice);
-
-      // This doesn't change e2e latency, but is recommended for saving an extra rpc call during the build phase
-      if (gasCoin) {
-        txb.setGasPayment([gasCoin]);
-      }
 
       const buildStartTime = performance.now();
       const bytes = await txb.build({ client: suiClient, limits: {} });
 
       const startTime = performance.now();
-      const { effects } = await suiClient.signAndExecuteTransactionBlock({signer: sender_keypair, transactionBlock: bytes, options: {
+      await suiClient.signAndExecuteTransactionBlock({signer: sender_keypair, transactionBlock: bytes, options: {
           showEffects: true,
       } });
 
-      gasCoin = effects.gasObject.reference;
-
-      const endTime = performance.now();cd
+      const endTime = performance.now();
 
       const buildLatency = (startTime - buildStartTime) / 1000;
       const latency = (endTime - startTime) / 1000;

--- a/sui/p2p_transfer/index.js
+++ b/sui/p2p_transfer/index.js
@@ -27,6 +27,7 @@ const main = async () => {
       url = URL_OVERRIDE;
   }
   const suiClient = new SuiClient({ url: url });
+  const gasPrice = await suiClient.getReferenceGasPrice()
   let gasCoin = null
 
   while (true) {
@@ -36,6 +37,7 @@ const main = async () => {
       txb.transferObjects([coin], sender_keypair.toSuiAddress());
       txb.setSender(sender_keypair.toSuiAddress());
       txb.setGasBudget(5_000_000)
+      txb.setGasPrice(gasPrice);
 
       // This doesn't change e2e latency, but is recommended for saving an extra rpc call during the build phase
       if (gasCoin) {
@@ -43,7 +45,7 @@ const main = async () => {
       }
 
       const buildStartTime = performance.now();
-      const bytes = await txb.build({ client: suiClient });
+      const bytes = await txb.build({ client: suiClient, limits: {} });
 
       const startTime = performance.now();
       const { effects } = await suiClient.signAndExecuteTransactionBlock({signer: sender_keypair, transactionBlock: bytes, options: {
@@ -52,7 +54,7 @@ const main = async () => {
 
       gasCoin = effects.gasObject.reference;
 
-      const endTime = performance.now();
+      const endTime = performance.now();cd
 
       const buildLatency = (startTime - buildStartTime) / 1000;
       const latency = (endTime - startTime) / 1000;

--- a/sui/p2p_transfer/index.js
+++ b/sui/p2p_transfer/index.js
@@ -6,7 +6,6 @@ import { getMetricPayload, pushMetrics, sleepAsync } from './common.js';
 
 const COIN_TRANSFER_LATENCY_METRIC_NAME = "e2e_p2p_txn_latency_sui";
 const COIN_TRANSFER_BUILD_LATENCY_METRIC_NAME = "e2e_p2p_txn_latency_build_sui";
-const COIN_TRANSFER_SUBMIT_LATENCY_METRIC_NAME = "e2e_p2p_txn_latency_sign_and_submit_sui";
 const COIN_TRANSFER_SUCCESS_METRIC_NAME = COIN_TRANSFER_LATENCY_METRIC_NAME + "_success";
 const CHAIN_NAME = process.env.CHAIN_NAME;
 const PING_INTERVAL = process.env.PING_INTERVAL * 1000;
@@ -21,10 +20,6 @@ const main = async () => {
   const SENDER_PRIVATE_KEY = process.env.ACC1_PRIVATE_KEY;
   const sender_keypair = getKeyPairFromExportedPrivateKey(SENDER_PRIVATE_KEY);
 
-  const RECIEVER_PRIVATE_KEY = process.env.ACC2_PRIVATE_KEY;
-  const receiver_keypair = getKeyPairFromExportedPrivateKey(RECIEVER_PRIVATE_KEY);
-  const receiver_address = receiver_keypair.getPublicKey().toSuiAddress();
-
 
   // create a new SuiClient object pointing to the network you want to use
   let url = getFullnodeUrl('mainnet');
@@ -32,39 +27,40 @@ const main = async () => {
       url = URL_OVERRIDE;
   }
   const suiClient = new SuiClient({ url: url });
+  let gasCoin = null
 
   while (true) {
     try {
       const txb = new TransactionBlock();
       const [coin] = txb.splitCoins(txb.gas, [txb.pure(1)]);
-      txb.transferObjects([coin], receiver_address);
+      txb.transferObjects([coin], sender_keypair.toSuiAddress());
       txb.setSender(sender_keypair.toSuiAddress());
       txb.setGasBudget(5_000_000)
+
+      // This doesn't change e2e latency, but is recommended for saving an extra rpc call during the build phase
+      if (gasCoin) {
+        txb.setGasPayment([gasCoin]);
+      }
 
       const buildStartTime = performance.now();
       const bytes = await txb.build({ client: suiClient });
 
       const startTime = performance.now();
-      await suiClient.signAndExecuteTransactionBlock({signer: sender_keypair, transactionBlock: bytes, options: {
-          showBalanceChanges: true,
+      const { effects } = await suiClient.signAndExecuteTransactionBlock({signer: sender_keypair, transactionBlock: bytes, options: {
           showEffects: true,
-          showEvents: true,
-          showInput: true,
-          showObjectChanges: true,
-          showRawInput: true,
       } });
+
+      gasCoin = effects.gasObject.reference;
 
       const endTime = performance.now();
 
       const buildLatency = (startTime - buildStartTime) / 1000;
-      const submitLatency = (endTime - startTime) / 1000;
       const latency = (endTime - startTime) / 1000;
-      console.log(`Build latency for p2p transfer: ${buildLatency} s; Submit Latency: ${submitLatency} s; E2E latency for p2p transfer: ${latency} s`);
+      console.log(`Build latency for p2p transfer: ${buildLatency} s; E2E latency for p2p transfer: ${latency} s`);
 
       pushMetrics(getMetricPayload(COIN_TRANSFER_LATENCY_METRIC_NAME, {"chain_name": CHAIN_NAME}, latency));
       pushMetrics(getMetricPayload(COIN_TRANSFER_SUCCESS_METRIC_NAME, {"chain_name": CHAIN_NAME}, 1));
       pushMetrics(getMetricPayload(COIN_TRANSFER_BUILD_LATENCY_METRIC_NAME, {"chain_name": CHAIN_NAME}, buildLatency));
-      pushMetrics(getMetricPayload(COIN_TRANSFER_SUBMIT_LATENCY_METRIC_NAME, {"chain_name": CHAIN_NAME}, submitLatency));
     } catch (error) {
       console.log('Error:', error.message);
       pushMetrics(getMetricPayload(COIN_TRANSFER_SUCCESS_METRIC_NAME, {"chain_name": CHAIN_NAME}, 0));

--- a/sui/shared_obj_incr/README.md
+++ b/sui/shared_obj_incr/README.md
@@ -1,0 +1,26 @@
+## Setup
+
+1. Copy the following files into the same directory:
+    * `package.json`
+    * `index.js`
+    * `common.js` from the root of the repo
+2. Install dependencies
+    * run `npm install`, or use another package manager like `pnpm` or `yarn`
+3. Get a private key with some sui for running the transfer test
+    * The key should look something like `suiprivkey123abc...`
+        * You can export a private key from the sui CLI using `sui keytool export --key-identity your-alias`
+    * For testing you can use the sui CLI to create a new keypair with testnet sui:
+        1. run `sui client new-address ed25519` to create a new keypair
+        2. run `sui client faucet` to request sui
+        3. run `sui keytool export --key-identity alias-from-ste-1`  to export the private key in the right format
+4. Publish the smart contract
+    * Make sure the sui CLI is set up for the same environment as you are testing against (testnet/mainnet)
+    * From the smart_contract/counter directory run `sui client publish --gas-budget 100000000` to publish the contract
+    * Note the newly published package ID, and the ID of the shared counter object for the next step
+5. Run `index.ts` with environment variables to run the benchmark
+    * To run against testnet run: `SMART_CONTRACT=<package-id> SHARED_OBJ_ON_CHAIN=<object-id> ACC1_PRIVATE_KEY=<private-key> URL=https://fullnode.testnet.sui.io:443 node index.js`
+    * To run against mainnet remove the URL variable `SMART_CONTRACT=<package-id> SHARED_OBJ_ON_CHAIN=<object-id> ACC1_PRIVATE_KEY=<private-key> node index.js`
+    * To report the metrics add the appropriate metrics environment variables:
+        - `SMART_CONTRACT=<package-id> SHARED_OBJ_ON_CHAIN=<object-id> METRICS_URL=<url> METRICS_AUTH_TOKEN=<token> METRICS_TAG=<tag> ACC1_PRIVATE_KEY=<private-key> node index.js`
+
+

--- a/sui/shared_obj_incr/index.js
+++ b/sui/shared_obj_incr/index.js
@@ -35,7 +35,6 @@ const main = async () => {
             showOwner: true
         }
     })
-    let gasCoin = null
 
     while (true) {
         try {
@@ -44,11 +43,6 @@ const main = async () => {
             txb.setGasPrice(gasPrice);
 
             txb.setGasBudget(5_000_000)
-
-            // This doesn't change e2e latency, but is recommended for saving an extra rpc call during the build phase
-            if (gasCoin) {
-                txb.setGasPayment([gasCoin]);
-            }
 
             // txb.object automatically converts the object ID to receiving transaction arguments if the moveCall expects it
             txb.moveCall({
@@ -66,11 +60,9 @@ const main = async () => {
             const bytes = await txb.build({ client: suiClient, limits: {} });
 
             const startTime = performance.now();
-            const { effects } = await suiClient.signAndExecuteTransactionBlock({signer: sender_keypair, transactionBlock: bytes, options: {
+            await suiClient.signAndExecuteTransactionBlock({signer: sender_keypair, transactionBlock: bytes, options: {
                 showEffects: true,
             } });
-
-            gasCoin = effects.gasObject.reference;
 
             const endTime = performance.now();
 

--- a/sui/shared_obj_incr/index.js
+++ b/sui/shared_obj_incr/index.js
@@ -6,7 +6,6 @@ import { getMetricPayload, pushMetrics, sleepAsync } from './common.js';
 
 const SHARED_OBJ_INCR_LATENCY_METRIC_NAME = "e2e_shared_obj_incr_txn_latency_sui";
 const SHARED_OBJ_INCR_BUILD_LATENCY_METRIC_NAME = "e2e_shared_obj_incr_txn_latency_build_sui";
-const SHARED_OBJ_INCR_SUBMIT_LATENCY_METRIC_NAME = "e2e_shared_obj_incr_txn_latency_sign_and_submit_sui";
 const SHARED_OBJ_INCR_SUCCESS_METRIC_NAME = SHARED_OBJ_INCR_LATENCY_METRIC_NAME + "_success";
 const CHAIN_NAME = process.env.CHAIN_NAME;
 const PING_INTERVAL = process.env.PING_INTERVAL * 1000;
@@ -29,12 +28,19 @@ const main = async () => {
         url = URL_OVERRIDE;
     }
     const suiClient = new SuiClient({ url: url });
+    let gasCoin = null
 
     while (true) {
         try {
             const txb = new TransactionBlock();
             txb.setSender(sender_keypair.toSuiAddress());
             txb.setGasBudget(5_000_000)
+
+            // This doesn't change e2e latency, but is recommended for saving an extra rpc call during the build phase
+            if (gasCoin) {
+                txb.setGasPayment([gasCoin]);
+              }
+
             // txb.object automatically converts the object ID to receiving transaction arguments if the moveCall expects it
             txb.moveCall({
                 target: `${SMART_CONTRACT}::counter::increment`,
@@ -47,26 +53,21 @@ const main = async () => {
             const bytes = await txb.build({ client: suiClient });
 
             const startTime = performance.now();
-            await suiClient.signAndExecuteTransactionBlock({signer: sender_keypair, transactionBlock: bytes, options: {
-                showBalanceChanges: true,
+            const { effects } = await suiClient.signAndExecuteTransactionBlock({signer: sender_keypair, transactionBlock: bytes, options: {
                 showEffects: true,
-                showEvents: true,
-                showInput: true,
-                showObjectChanges: true,
-                showRawInput: true,
             } });
+
+            gasCoin = effects.gasObject.reference;
 
             const endTime = performance.now();
 
             const buildLatency = (startTime - buildStartTime) / 1000;
-            const submitLatency = (endTime - startTime) / 1000;
             const latency = (endTime - startTime) / 1000;
-            console.log(`Build latency for shared obj increment: ${buildLatency} s; Submit Latency: ${submitLatency} s; E2E latency for shared obj increment: ${latency} s`);
+            console.log(`Build latency for shared obj increment: ${buildLatency} s; E2E latency for shared obj increment: ${latency} s`);
 
             pushMetrics(getMetricPayload(SHARED_OBJ_INCR_LATENCY_METRIC_NAME, {"chain_name": CHAIN_NAME}, latency));
             pushMetrics(getMetricPayload(SHARED_OBJ_INCR_SUCCESS_METRIC_NAME, {"chain_name": CHAIN_NAME}, 1));
             pushMetrics(getMetricPayload(SHARED_OBJ_INCR_BUILD_LATENCY_METRIC_NAME, {"chain_name": CHAIN_NAME}, buildLatency));
-            pushMetrics(getMetricPayload(SHARED_OBJ_INCR_SUBMIT_LATENCY_METRIC_NAME, {"chain_name": CHAIN_NAME}, submitLatency));
         } catch (error) {
             console.log('Error:', error.message);
             pushMetrics(getMetricPayload(SHARED_OBJ_INCR_SUCCESS_METRIC_NAME, {"chain_name": CHAIN_NAME}, 0));


### PR DESCRIPTION
This PR updates the sui implementations to more accurately resemble the aptos example which has some additional metrics.  I've update the examples to break down the build/submission metrics the same way, and I removed the calls to `waitForTransactionBlock` which is only used to ensure that the transaction has been fully indexed (the transaction block is guaranteed to have reached finality before it is returned from the signAndExecuteTransactionBlock method).

 Let me know if there is anything else you want me to add the the sui exmaples!