### PR TITLE
Sui: set gas price of the transaction block about 10% higher than the ref gas price

### DIFF
--- a/sui/p2p_transfer/index.js
+++ b/sui/p2p_transfer/index.js
@@ -25,7 +25,7 @@ const main = async () => {
 
 
   // create a new SuiClient object pointing to the network you want to use
-  let url = getFullnodeUrl('mainnet');
+  let url = getFullnodeUrl(CHAIN_NAME);
   if (URL_OVERRIDE) {
       url = URL_OVERRIDE;
   }
@@ -39,7 +39,7 @@ const main = async () => {
       txb.transferObjects([coin], receiver_address);
       txb.setSender(sender_keypair.toSuiAddress());
       txb.setGasBudget(5_000_000)
-      txb.setGasPrice(gasPrice);
+      txb.setGasPrice(Math.floor(Number(gasPrice) * 1.1));
 
       const buildStartTime = performance.now();
       const bytes = await txb.build({ client: suiClient, limits: {} });

--- a/sui/shared_obj_incr/index.js
+++ b/sui/shared_obj_incr/index.js
@@ -23,7 +23,7 @@ const main = async () => {
     const sender_keypair = getKeyPairFromExportedPrivateKey(SENDER_PRIVATE_KEY);
 
     // create a new SuiClient object pointing to the network you want to use
-    let url = getFullnodeUrl('mainnet');
+    let url = getFullnodeUrl(CHAIN_NAME);
     if (URL_OVERRIDE) {
         url = URL_OVERRIDE;
     }
@@ -40,7 +40,7 @@ const main = async () => {
         try {
             const txb = new TransactionBlock();
             txb.setSender(sender_keypair.toSuiAddress());
-            txb.setGasPrice(gasPrice);
+            txb.setGasPrice(Math.floor(Number(gasPrice) * 1.1));
 
             txb.setGasBudget(5_000_000)
 


### PR DESCRIPTION
Making this change because we saw some instances of the below error:

`"Error: Transaction execution failed due to issues with transaction inputs, please review the errors and try again: Gas price 752 under reference gas price (RGP) 757."`