### PR TITLE
[Aptos] Skip unnecessary indexer wait.

### DIFF
--- a/aptos/p2p_transfer/index.js
+++ b/aptos/p2p_transfer/index.js
@@ -73,7 +73,7 @@ const main = async () => {
       });
 
       const submitEndTime = performance.now();
-      await aptos.waitForTransaction({ transactionHash: committedTransaction.hash });
+      await aptos.waitForTransaction({ transactionHash: committedTransaction.hash, options: { waitForIndexer: false } });
 
       const endTime = performance.now();
 


### PR DESCRIPTION
This PR updates the Aptos P2P transfer benchmark to avoid waiting for the indexer to update. This is unnecessary as the transaction is fully committed, and the indexer is a separate (orthogonal) step.